### PR TITLE
Reduxの設定

### DIFF
--- a/frontend/C/frontend-C/package-lock.json
+++ b/frontend/C/frontend-C/package-lock.json
@@ -8,11 +8,12 @@
       "name": "frontend-b",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.9.1",
+        "@types/react-redux": "^7.1.25",
         "install": "^0.13.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^8.0.5",
-        "redux": "^4.2.0"
+        "react-redux": "^8.0.5"
       },
       "devDependencies": {
         "@types/react": "^18.0.26",
@@ -920,6 +921,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.1.tgz",
+      "integrity": "sha512-HikrdY+IDgRfRYlCTGUQaiCxxDDgM1mQrRbZ6S1HFZX5ZYuJ4o8EstNmhTwHdPl2rTmLxzwSu0b3AyeyTlR+RA==",
+      "dependencies": {
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -963,6 +987,17 @@
       "devOptional": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.25",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.25.tgz",
+      "integrity": "sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/scheduler": {
@@ -2712,6 +2747,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
+      "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3648,6 +3692,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -3681,6 +3733,11 @@
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       }
+    },
+    "node_modules/reselect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -4856,6 +4913,17 @@
         "fastq": "^1.6.0"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.1.tgz",
+      "integrity": "sha512-HikrdY+IDgRfRYlCTGUQaiCxxDDgM1mQrRbZ6S1HFZX5ZYuJ4o8EstNmhTwHdPl2rTmLxzwSu0b3AyeyTlR+RA==",
+      "requires": {
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
+      }
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -4899,6 +4967,17 @@
       "devOptional": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.25",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.25.tgz",
+      "integrity": "sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/scheduler": {
@@ -6142,6 +6221,11 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
+    "immer": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
+      "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6784,6 +6868,12 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "requires": {}
+    },
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -6805,6 +6895,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "reselect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/frontend/C/frontend-C/package.json
+++ b/frontend/C/frontend-C/package.json
@@ -9,11 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.1",
+    "@types/react-redux": "^7.1.25",
     "install": "^0.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^8.0.5",
-    "redux": "^4.2.0"
+    "react-redux": "^8.0.5"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",

--- a/frontend/C/frontend-C/src/App.tsx
+++ b/frontend/C/frontend-C/src/App.tsx
@@ -1,8 +1,32 @@
 import './App.css';
-import React from 'react';
+import { useAppDispatch, useAppSelector } from './redux/hooks';
+import { moveRight, moveLeft } from './redux/wordListSlice';
 
 const App = () => {
-  return <div className="App"></div>;
+
+  const leftSideWordList = useAppSelector(
+    (state) => state.wordList.leftSideWordList,
+  );
+  const rightSideWordList = useAppSelector(
+    (state) => state.wordList.rightSideWordList,
+  );
+  const dispatch = useAppDispatch();
+  return (
+    <div className="App">
+      <ul>
+        {leftSideWordList.map((v, i) => {
+          return <li key={i}>{v}</li>;
+        })}
+        <button onClick={() =>  dispatch(moveRight())}>右へ</button>
+      </ul>
+      <ul>
+        {rightSideWordList.map((v, i) => {
+          return <li key={i}>{v}</li>;
+        })}
+        <button onClick={() => dispatch(moveLeft())}>左へ</button>
+      </ul>
+    </div>
+  );
 };
 
 export default App;

--- a/frontend/C/frontend-C/src/main.tsx
+++ b/frontend/C/frontend-C/src/main.tsx
@@ -1,10 +1,14 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import App from "./App";
-import "./index.css";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+import { Provider } from 'react-redux';
+import { store } from './redux/store';
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <Provider store={store}>
+      <App />
+    </Provider>
+  </React.StrictMode>,
 );

--- a/frontend/C/frontend-C/src/redux/hooks.ts
+++ b/frontend/C/frontend-C/src/redux/hooks.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from './store';
+
+// Use throughout this app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/frontend/C/frontend-C/src/redux/store.ts
+++ b/frontend/C/frontend-C/src/redux/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import wordListReducer from './wordListSlice';
+
+export const store = configureStore({
+  reducer: {
+    wordList: wordListReducer,
+  },
+});
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>;
+// Inferred type: {wordList: wordListState}
+export type AppDispatch = typeof store.dispatch;

--- a/frontend/C/frontend-C/src/redux/wordListSlice.ts
+++ b/frontend/C/frontend-C/src/redux/wordListSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface wordListState {
+  leftSideWordList: String[];
+  rightSideWordList: String[];
+}
+
+const initialState: wordListState = {
+  leftSideWordList: ['Apple', 'Grape', 'Strawberry', 'Cherry', 'Plum'],
+  rightSideWordList: ['watermelon', 'Banana', 'Peach'],
+};
+
+export const wordListSlice = createSlice({
+  name: 'move word',
+  initialState,
+  reducers: {
+    moveRight: (state) => {
+      const index = state.leftSideWordList.length;
+      if (index < 1) {
+        return;
+      }
+      const moveWord = state.leftSideWordList[index - 1];
+      state.leftSideWordList = state.leftSideWordList.slice(0, index - 1);
+      state.rightSideWordList = [...state.rightSideWordList, moveWord];
+    },
+    moveLeft: (state) => {
+      const index = state.rightSideWordList.length;
+      if (index < 1) {
+        return;
+      }
+      const moveWord = state.rightSideWordList[index - 1];
+      state.rightSideWordList = state.rightSideWordList.slice(0, index - 1);
+      state.leftSideWordList = [...state.leftSideWordList, moveWord];
+    },
+  },
+});
+
+export const { moveRight, moveLeft } = wordListSlice.actions;
+export default wordListSlice.reducer;

--- a/frontend/C/frontend-C/tsconfig.json
+++ b/frontend/C/frontend-C/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/C/frontend-C/tsconfig.node.json
+++ b/frontend/C/frontend-C/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/C/frontend-C/vite.config.ts
+++ b/frontend/C/frontend-C/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
- コードベースのコピペ漏れファイルを追加

##  Redux
- redux toolkitのインポート(redux coreは削除)
- スライスを作成
- ストアを作成
- 型定義ファイルを作成
- viewにStoreを渡す
- store情報を用いたviewの仮実装

参考:  https://redux.js.org/tutorials/typescript-quick-start